### PR TITLE
add get type function

### DIFF
--- a/pkg/ssf_events/credential_change_event.go
+++ b/pkg/ssf_events/credential_change_event.go
@@ -100,3 +100,7 @@ func (event *CredentialChangeEvent) GetCredentialType() CredentialType {
 func (event *CredentialChangeEvent) GetChangeType() ChangeType {
 	return event.ChangeType
 }
+
+func (event *CredentialChangeEvent) GetType() EventType {
+	return CredentialChange
+}

--- a/pkg/ssf_events/session_revoked_event.go
+++ b/pkg/ssf_events/session_revoked_event.go
@@ -40,3 +40,7 @@ func (event *SessionRevokedEvent) GetSubject() map[string]interface{} {
 func (event *SessionRevokedEvent) GetTimestamp() int64 {
 	return event.EventTimestamp
 }
+
+func (event *SessionRevokedEvent) GetType() EventType {
+	return SessionRevoked
+}

--- a/pkg/ssf_events/ssf_event.go
+++ b/pkg/ssf_events/ssf_event.go
@@ -52,6 +52,9 @@ type SsfEvent interface {
 
 	// Returns the Unix timestamp of the event
 	GetTimestamp() int64
+
+	// Return the type of event
+	GetType() EventType
 }
 
 var EventUri = map[EventType]string{


### PR DESCRIPTION
The only way to return something dynamically in Golang is to return it into an `interface{}`. So the current implementation is already fine. Once we get the event type using `GetType()`, we will do a type cast. 