### PR TITLE
Subject Extraction Fix

### DIFF
--- a/pkg/ssf_events/ssf_event.go
+++ b/pkg/ssf_events/ssf_event.go
@@ -81,6 +81,22 @@ var EventEnum = map[string]EventType{
 	"https://schemas.openid.net/secevent/caep/event-type/stream-updated":           StreamUpdatedEventType,
 }
 
+func extractSubject(claimsJson map[string]interface{}, subjectAttributes map[string]interface{}) (map[string]interface{}, error) {
+	if subId, ok := claimsJson["sub_id"]; ok {
+		if mapSubID, ok := subId.(map[string]interface{}); ok {
+			return mapSubID, nil
+		}
+	}
+
+	if subject, ok := subjectAttributes["subject"]; ok {
+		if mapSubject, ok := subject.(map[string]interface{}); ok {
+			return mapSubject, nil
+		}
+	}
+
+	return nil, errors.New("cannot retrieve subject of an event")
+}
+
 // Takes an event subject from the JSON of an SSF Event, and converts it into the matching struct for that event
 func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson map[string]interface{}) (SsfEvent, error) {
 	eventEnum := EventEnum[eventUri]
@@ -126,9 +142,9 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 
 	timestamp := int64(floatTimestamp)
 
-	subject, ok := claimsJson["sub_id"].(map[string]interface{})
-	if !ok {
-		return nil, errors.New("unable to parse event subject")
+	subject, err := extractSubject(claimsJson, subjectAttributes)
+	if err != nil {
+		return nil, err
 	}
 
 	format, err := GetSubjectFormat(subject)

--- a/pkg/ssf_events/ssf_event.go
+++ b/pkg/ssf_events/ssf_event.go
@@ -81,7 +81,7 @@ var EventEnum = map[string]EventType{
 	"https://schemas.openid.net/secevent/caep/event-type/stream-updated":           StreamUpdatedEventType,
 }
 
-func extractSubject(claimsJson map[string]interface{}, subjectAttributes map[string]interface{}) (map[string]interface{}, error) {
+func extractSubject(claimsJson, subjectAttributes map[string]interface{}) (map[string]interface{}, error) {
 	if subId, ok := claimsJson["sub_id"]; ok {
 		if mapSubID, ok := subId.(map[string]interface{}); ok {
 			return mapSubID, nil

--- a/pkg/ssf_events/ssf_event.go
+++ b/pkg/ssf_events/ssf_event.go
@@ -82,13 +82,13 @@ var EventEnum = map[string]EventType{
 }
 
 func extractSubject(claimsJson, subjectAttributes map[string]interface{}) (map[string]interface{}, error) {
-	if subId, ok := claimsJson["sub_id"]; ok {
+	if subId, found := claimsJson["sub_id"]; found {
 		if mapSubID, ok := subId.(map[string]interface{}); ok {
 			return mapSubID, nil
 		}
 	}
 
-	if subject, ok := subjectAttributes["subject"]; ok {
+	if subject, found := subjectAttributes["subject"]; found {
 		if mapSubject, ok := subject.(map[string]interface{}); ok {
 			return mapSubject, nil
 		}

--- a/pkg/ssf_events/ssf_event.go
+++ b/pkg/ssf_events/ssf_event.go
@@ -126,7 +126,12 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 
 	timestamp := int64(floatTimestamp)
 
-	format, err := GetSubjectFormat(subjectAttributes["subject"].(map[string]interface{}))
+	subject, ok := claimsJson["sub_id"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("unable to parse event subject")
+	}
+
+	format, err := GetSubjectFormat(subject)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +162,7 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 		event := CredentialChangeEvent{
 			Json:           claimsJson,
 			Format:         format,
-			Subject:        subjectAttributes["subject"].(map[string]interface{}),
+			Subject:        subject,
 			EventTimestamp: timestamp,
 			CredentialType: credentialType,
 			ChangeType:     changeType,
@@ -168,7 +173,7 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 		event := SessionRevokedEvent{
 			Json:           claimsJson,
 			Format:         format,
-			Subject:        subjectAttributes["subject"].(map[string]interface{}),
+			Subject:        subject,
 			EventTimestamp: timestamp,
 		}
 		return &event, nil
@@ -187,7 +192,7 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 		event := DeviceComplianceEvent{
 			Json:           claimsJson,
 			Format:         format,
-			Subject:        subjectAttributes["subject"].(map[string]interface{}),
+			Subject:        subject,
 			EventTimestamp: timestamp,
 			PreviousStatus: previousStatus,
 			CurrentStatus:  currentStatus,
@@ -211,7 +216,7 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 		event := AssuranceLevelChangeEvent{
 			Json:            claimsJson,
 			Format:          format,
-			Subject:         subjectAttributes["subject"].(map[string]interface{}),
+			Subject:         subject,
 			EventTimestamp:  timestamp,
 			Namespace:       namespace,
 			PreviousLevel:   &previousLevel,
@@ -229,7 +234,7 @@ func EventStructFromEvent(eventUri string, eventSubject interface{}, claimsJson 
 		event := TokenClaimsChangeEvent{
 			Json:           claimsJson,
 			Format:         format,
-			Subject:        subjectAttributes["subject"].(map[string]interface{}),
+			Subject:        subject,
 			EventTimestamp: timestamp,
 			Claims:         claims,
 		}


### PR DESCRIPTION
The SSF specification requires that the 'sub_id' field at the root level must contain the subject. However, the current implementation of the receiver incorrectly searches for the subject within the optional 'subject' field located inside the 'events' field. This pull request addresses this issue by modifying the logic to first look for the 'sub_id' field. And if it fails to extract the subject from the 'sub_id' field, then look for the 'subject' field.

Relevant SSF Spec documentation: https://openid.github.io/sharedsignals/openid-sharedsignals-framework-1_0.html#:~:text=3.%20Subject,existing%20event%20types.